### PR TITLE
Various fixes, mainly around regexes and binaries tests

### DIFF
--- a/testcases/alternativesTests/binaries_test_methods.py
+++ b/testcases/alternativesTests/binaries_test_methods.py
@@ -126,7 +126,11 @@ class GetAllBinariesAndSlaves(btp.PathTest):
         return self.installed_binaries, self.installed_slaves
 
     def _get_binary_directory_path(self, name):
-        return JVM_DIR + "/" + pkgsplit.get_jvm_dir_pre_change(name)
+        binary_dir_path = JVM_DIR + "/" + pkgsplit.get_jvm_dir_pre_change(name)
+        _subpkg = tu.rename_default_subpkg(pkgsplit.get_subpackage_only(name))
+        if "headless" in _subpkg or "default" in _subpkg :
+            binary_dir_path += "/jre"
+        return binary_dir_path
 
 
 
@@ -155,6 +159,7 @@ class BinarySlaveTestMethods(GetAllBinariesAndSlaves):
                 except KeyError:
                     la.LoggingAccess().log("Subpkg " + current_subpkg + " not containing binaries and is probably "
                                                                         "missing. This is being reported in subpkg test.")
+                    continue
                 for j in jre:
                     try:
                         sdk.remove(j)

--- a/testcases/alternativesTests/permissions_test.py
+++ b/testcases/alternativesTests/permissions_test.py
@@ -101,7 +101,7 @@ class BaseTest(JdkConfiguration):
     def _parse_output(self, out, subpackage):
         """Output of the file listing must be parsed into something more readable and easier to process."""
         return_targets = []
-        header = re.compile("/[^:]*:")
+        header = re.compile(r"/[^:]*:")
         current_header = ""
         for line in out:
             if line == "":

--- a/testcases/nameTest/connfigs/initbuild_config.py
+++ b/testcases/nameTest/connfigs/initbuild_config.py
@@ -63,7 +63,7 @@ class OthersVersionCheck(DefaultCheck):
             " For modern jdks (jdk 9+)  the major version is just plain number. Eg.: java-9-ibm."
             " The extracted middle number *is* number")
         la.LoggingAccess().log("non itw call for checkMajorVersionSimplified")
-        return re.compile("[0-9]+").match(version) and int(version) > 0
+        return re.compile(r"[0-9]+").match(version) and int(version) > 0
 
     def checkMajorVersion(self, version=None):
         self._document("The version string in middle of package name is one of: " + ",".join(

--- a/testcases/nameTest/connfigs/nametest_config.py
+++ b/testcases/nameTest/connfigs/nametest_config.py
@@ -3,25 +3,25 @@ import re
 import outputControl.logging_access as la
 from utils.core.configuration_specific import JdkConfiguration
 
-JAVA_REGEX8="^java-(1\.[5-8]\.[0-9])-.*-.*-.*\..*.rpm$"
+JAVA_REGEX8=r"^java-(1\.[5-8]\.[0-9])-.*-.*-.*\..*.rpm$"
 # java-1.X.0 or just 9-whatever1-whatever2-whatever3.whatever4.rpm
 # w1 = vendor, w2 = version
 # w3 = release, w4 = arch .rpm
 CRES_JAVA_REGEXE8 = re.compile(JAVA_REGEX8)
 
-JAVA_REGEX9="^java-([1-9][0-9]*)-.*-.*-.*\..*.rpm$"
+JAVA_REGEX9=r"^java-([1-9][0-9]*)-.*-.*-.*\..*.rpm$"
 CRES_JAVA_REGEXE9 = re.compile(JAVA_REGEX9)
 
-JAVA_REGEX10="^java-([10-20])-.*-.*-.*\..*.rpm$"
+JAVA_REGEX10=r"^java-([10-20])-.*-.*-.*\..*.rpm$"
 CRES_JAVA_REGEXE10 = re.compile(JAVA_REGEX9)
 
-JAVA_REGEX_ROLLING="^java-latest-openjdk.*-.*\..*.rpm$"
+JAVA_REGEX_ROLLING=r"^java-latest-openjdk.*-.*\..*.rpm$"
 CRES_JAVA_REGEXEROLLING = re.compile(JAVA_REGEX_ROLLING)
 
-ITW_REGEX="^icedtea-web-.*-.*\..*.rpm$"
+ITW_REGEX=r"^icedtea-web-.*-.*\..*.rpm$"
 CRES_ITW_REGEXE = re.compile(ITW_REGEX)
 
-TEMURIN_REGEX="^temurin-([0-9]*)-.*-.*-.*\..*.rpm$"
+TEMURIN_REGEX=r"^temurin-([0-9]*)-.*-.*-.*\..*.rpm$"
 CRES_TEMURIN_REGEXE = re.compile(TEMURIN_REGEX)
 
 class ItwRegexCheck(JdkConfiguration):

--- a/utils/pkg_name_split.py
+++ b/utils/pkg_name_split.py
@@ -169,7 +169,7 @@ def get_name_version_release(name):
 
 
 def simplify_version(vers):
-    old_naming_regex = re.compile("^[0-9].[0-9].[0-9]$")
+    old_naming_regex = re.compile(r"^[0-9].[0-9].[0-9]$")
     if old_naming_regex.match(vers):
         return vers.split(".")[1]
     return vers


### PR DESCRIPTION
- ghost_test fixed, headless-debug packages contain hardcoded classes 
   again
- changing regex strings to raw strings
- jre binaries are in jre/bin subdirectory, not bin
- continue loop in binaries test if no jre binaries found, no need to mark it as fail twice and aborting testsuite because of it